### PR TITLE
Get `WalletSummary` on CBP start and use it to bound subtree roots

### DIFF
--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
@@ -46,8 +46,8 @@ class JniWalletSummary(
         require(progressNumerator.toFloat().div(progressDenominator) <= 1f) {
             "Result of ${progressNumerator.toFloat()}/$progressDenominator is outside of allowed range"
         }
-        require(nextSaplingSubtreeIndex >= 0L) {
-            "Numerator $nextSaplingSubtreeIndex is outside of allowed range [0, Long.MAX_VALUE]"
+        require(nextSaplingSubtreeIndex.isInUIntRange()) {
+            "Height $nextSaplingSubtreeIndex is outside of allowed UInt range"
         }
     }
 }

--- a/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/DarksideTestCoordinator.kt
+++ b/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/DarksideTestCoordinator.kt
@@ -3,7 +3,6 @@ package cash.z.ecc.android.sdk.darkside.test
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import cash.z.ecc.android.sdk.ext.Darkside
-import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.lightwallet.client.internal.DarksideApi
@@ -202,20 +201,6 @@ class DarksideTestCoordinator(val wallet: TestWallet) {
                     "invalid total balance. Expected a minimum of $total but found ${balance?.total}",
                     total <= balance?.total?.value!!
                 )
-            }
-        }
-
-        suspend fun validateBalance(
-            available: Long = -1,
-            total: Long = -1,
-            account: Account
-        ) {
-            val balance = synchronizer.processor.getBalanceInfo(account)
-            if (available > 0) {
-                assertEquals("invalid available balance", available, balance.available)
-            }
-            if (total > 0) {
-                assertEquals("invalid total balance", total, balance.total)
             }
         }
     }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/LightWalletClient.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/LightWalletClient.kt
@@ -83,9 +83,9 @@ interface LightWalletClient {
      * @throws IllegalArgumentException when empty argument provided
      */
     fun getSubtreeRoots(
-        startIndex: Int,
+        startIndex: UInt,
         shieldedProtocol: ShieldedProtocolEnum,
-        maxEntries: Int
+        maxEntries: UInt
     ): Flow<Response<SubtreeRootUnsafe>>
 
     /**

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/internal/LightWalletClientImpl.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/internal/LightWalletClientImpl.kt
@@ -207,18 +207,14 @@ internal class LightWalletClientImpl private constructor(
     }
 
     override fun getSubtreeRoots(
-        startIndex: Int,
+        startIndex: UInt,
         shieldedProtocol: ShieldedProtocolEnum,
-        maxEntries: Int
+        maxEntries: UInt
     ): Flow<Response<SubtreeRootUnsafe>> {
-        require(startIndex >= 0 && maxEntries >= 0) {
-            "${Constants.ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE_COMMON} startIndex: $startIndex, maxEntries: $maxEntries."
-        }
-
         val getSubtreeRootsArgBuilder = Service.GetSubtreeRootsArg.newBuilder()
-        getSubtreeRootsArgBuilder.startIndex = startIndex
+        getSubtreeRootsArgBuilder.startIndex = startIndex.toInt()
         getSubtreeRootsArgBuilder.shieldedProtocol = shieldedProtocol.toProtocol()
-        getSubtreeRootsArgBuilder.maxEntries = maxEntries
+        getSubtreeRootsArgBuilder.maxEntries = maxEntries.toInt()
 
         val request = getSubtreeRootsArgBuilder.build()
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -363,26 +363,10 @@ class SdkSynchronizer private constructor(
      * because of the current limited Orchard support.
      */
     suspend fun refreshAllBalances() {
-        processor.checkAllBalances()
+        processor.refreshWalletSummary()
         // TODO [#682]: refresh orchard balance
         // TODO [#682]: https://github.com/zcash/zcash-android-wallet-sdk/issues/682
         Twig.warn { "Warning: Orchard balance does not yet refresh. Only some of the plumbing is in place." }
-    }
-
-    /**
-     * Calculate the latest Sapling balance based on the blocks that have been scanned and transmit this information
-     * into the [saplingBalances] flow.
-     */
-    suspend fun refreshSaplingBalance() {
-        processor.checkSaplingBalance()
-    }
-
-    /**
-     * Calculate the latest Transparent balance based on the blocks that have been scanned and transmit this information
-     * into the [saplingBalances] flow.
-     */
-    suspend fun refreshTransparentBalance() {
-        processor.checkTransparentBalance()
     }
 
     suspend fun isValidAddress(address: String): Boolean {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -716,15 +716,6 @@ class CompactBlockProcessor internal constructor(
     }
 
     /**
-     * Calculate the latest Transparent balance, based on the blocks that have been scanned and transmit this
-     * information into the internal [transparentBalances] flow.
-     */
-    internal suspend fun checkTransparentBalance() {
-        Twig.debug { "Checking Transparent balance" }
-        transparentBalances.value = getUtxoCacheBalance(getTransparentAddress(backend, Account.DEFAULT))
-    }
-
-    /**
      * Update the latest balances using the given wallet summary, and transmit this information
      * into the related internal flows. Note that the Orchard balance is not supported.
      */
@@ -732,10 +723,17 @@ class CompactBlockProcessor internal constructor(
         summary.accountBalances[Account.DEFAULT]?.let {
             Twig.debug { "Updating Sapling balance" }
             saplingBalances.value = it.sapling
-            // TODO [#682]: refresh orchard balance
+            // TODO [#682]: Uncomment this once we have Orchard support.
             // TODO [#682]: https://github.com/zcash/zcash-android-wallet-sdk/issues/682
+            // orchardBalances.value = it.orchard
+            // We only allow stored transparent balance to be shielded, and we do so with
+            // a zero-conf transaction, so treat all unshielded balance as available.
+            transparentBalances.value =
+                WalletBalance(
+                    it.unshielded,
+                    it.unshielded
+                )
         }
-        checkTransparentBalance()
     }
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -1115,8 +1115,8 @@ class CompactBlockProcessor internal constructor(
 
             retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
                 downloader.getSubtreeRoots(
-                    startIndex = 0,
-                    maxEntries = 0,
+                    startIndex = UInt.MIN_VALUE,
+                    maxEntries = UInt.MIN_VALUE,
                     shieldedProtocol = ShieldedProtocolEnum.SAPLING
                 ).onEach { response ->
                     when (response) {
@@ -1177,7 +1177,7 @@ class CompactBlockProcessor internal constructor(
         @VisibleForTesting
         internal suspend fun putSaplingSubtreeRoots(
             backend: TypesafeBackend,
-            startIndex: Long = 0,
+            startIndex: UInt,
             subTreeRootList: List<SubtreeRoot>,
             lastValidHeight: BlockHeight
         ): PutSaplingSubtreeRootsResult {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
@@ -6,7 +6,10 @@ import cash.z.ecc.android.sdk.internal.model.SubtreeRoot
  * Internal class for get subtree roots action result.
  */
 internal sealed class GetSubtreeRootsResult {
-    data class SpendBeforeSync(val subTreeRootList: List<SubtreeRoot>) : GetSubtreeRootsResult()
+    data class SpendBeforeSync(
+        val startIndex: UInt,
+        val subTreeRootList: List<SubtreeRoot>
+    ) : GetSubtreeRootsResult()
 
     data object Linear : GetSubtreeRootsResult()
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -82,7 +82,7 @@ internal interface TypesafeBackend {
      */
     @Throws(RuntimeException::class)
     suspend fun putSaplingSubtreeRoots(
-        startIndex: Long,
+        startIndex: UInt,
         roots: List<SubtreeRoot>,
     )
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -158,10 +158,10 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
     override suspend fun initDataDb(seed: ByteArray?): Int = backend.initDataDb(seed)
 
     override suspend fun putSaplingSubtreeRoots(
-        startIndex: Long,
+        startIndex: UInt,
         roots: List<SubtreeRoot>
     ) = backend.putSaplingSubtreeRoots(
-        startIndex = startIndex,
+        startIndex = startIndex.toLong(),
         roots =
             roots.map {
                 JniSubtreeRoot.new(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
@@ -169,9 +169,9 @@ open class CompactBlockDownloader private constructor(val compactBlockRepository
      * @return a flow of information about roots of subtrees of the Sapling and Orchard note commitment trees.
      */
     suspend fun getSubtreeRoots(
-        startIndex: Int,
+        startIndex: UInt,
         shieldedProtocol: ShieldedProtocolEnum,
-        maxEntries: Int
+        maxEntries: UInt
     ) = lightWalletClient.getSubtreeRoots(
         startIndex = startIndex,
         shieldedProtocol = shieldedProtocol,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/AccountBalance.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/AccountBalance.kt
@@ -4,7 +4,9 @@ import cash.z.ecc.android.sdk.model.WalletBalance
 import cash.z.ecc.android.sdk.model.Zatoshi
 
 internal data class AccountBalance(
-    val sapling: WalletBalance
+    val sapling: WalletBalance,
+    val orchard: WalletBalance,
+    val unshielded: Zatoshi
 ) {
     companion object {
         fun new(jni: JniAccountBalance): AccountBalance {
@@ -13,7 +15,13 @@ internal data class AccountBalance(
                     WalletBalance(
                         Zatoshi(jni.saplingTotalBalance),
                         Zatoshi(jni.saplingVerifiedBalance)
-                    )
+                    ),
+                orchard =
+                    WalletBalance(
+                        Zatoshi(jni.orchardTotalBalance),
+                        Zatoshi(jni.orchardVerifiedBalance)
+                    ),
+                unshielded = Zatoshi(jni.unshieldedBalance)
             )
         }
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
@@ -8,7 +8,7 @@ internal data class WalletSummary(
     val chainTipHeight: BlockHeight,
     val fullyScannedHeight: BlockHeight,
     val scanProgress: ScanProgress,
-    val nextSaplingSubtreeIndex: Long
+    val nextSaplingSubtreeIndex: UInt
 ) {
     companion object {
         fun new(jni: JniWalletSummary): WalletSummary {
@@ -20,7 +20,7 @@ internal data class WalletSummary(
                 chainTipHeight = BlockHeight(jni.chainTipHeight),
                 fullyScannedHeight = BlockHeight(jni.fullyScannedHeight),
                 scanProgress = ScanProgress.new(jni),
-                nextSaplingSubtreeIndex = jni.nextSaplingSubtreeIndex
+                nextSaplingSubtreeIndex = jni.nextSaplingSubtreeIndex.toUInt()
             )
         }
     }


### PR DESCRIPTION
This improves performance in two ways:
- The `SdkSynchronizer` now reports balances of existing wallets and sync progress almost immediately, instead of after the first batch of blocks is scanned.
- In the steady state case, only a few subtree roots are downloaded, reducing the time until the first batch of blocks is scanned.

The transparent balance flow is now also refreshed from `WalletSummary`, instead of only showing the balance of the default transparent address. We now also treat the zero-conf balance as the full available transparent balance (as we already do when actually shielding it).

Closes Electric-Coin-Company/zcash-android-wallet-sdk#1310.

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._