### PR TITLE
[#1435] Eliminate logging with Proguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The SDK components no longer contain logging statements in the release build
 - Gradle 8.7
 - Android Gradle Plugin 8.3.0
 - Kotlin 1.9.23

--- a/sdk-lib/proguard-consumer.txt
+++ b/sdk-lib/proguard-consumer.txt
@@ -1,0 +1,9 @@
+# Strip out log messages
+-assumenosideeffects public class cash.z.ecc.android.sdk.internal.Twig {
+    public static *** verbose(...);
+    public static *** debug(...);
+    public static *** info(...);
+    public static *** warn(...);
+    public static *** error(...);
+    public static *** assertLoggingStripped();
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -571,6 +571,8 @@ interface Synchronizer {
 
             validateAlias(alias)
 
+            validateLogging()
+
             val saplingParamTool = SaplingParamTool.new(applicationContext)
 
             val loadedCheckpoint =
@@ -737,5 +739,12 @@ private fun validateAlias(alias: String) {
     ) {
         "ERROR: Invalid alias ($alias). For security, the alias must be shorter than 100 " +
             "characters and only contain letters, digits, hyphens, and underscores."
+    }
+}
+
+private fun validateLogging() {
+    if (!BuildConfig.DEBUG) {
+        // In release builds, logs should be stripped by R8 rules
+        Twig.assertLoggingStripped()
     }
 }


### PR DESCRIPTION
- Closes #1435
- Changelog update

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._