### PR TITLE
[#1501] Support same monetary separators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ captures/
 .idea/deploymentTargetSelector.xml
 .idea/other.xml
 .idea/studiobot.xml
+.idea/deviceManager.xml
 *.iml
 
 # Keystore files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wallet secrets.
 
 ### Changed
+- `ZecString` and `Zatoshi` APIs now handle `MonetarySeparators` with the same grouping and decimal characters
 - Checkpoints update
+
+### Fixed
+- `MonetarySeparators` API does not signal an unsupported state to clients if used on a device with Locale with the 
+ same decimal and grouping separators. Instead, it will just omit the grouping separator.
 
 ## [2.1.1] - 2024-04-23
 

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/ZatoshiExt.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/ZatoshiExt.kt
@@ -64,6 +64,7 @@ private fun BigDecimal.convertZecDecimalToFiatDecimal(zecPrice: BigDecimal): Big
     return multiply(zecPrice, MathContext.DECIMAL128)
 }
 
+@Suppress("NestedBlockDepth")
 private fun BigDecimal.convertFiatDecimalToFiatString(
     fiatCurrency: Currency,
     locale: java.util.Locale,
@@ -76,7 +77,9 @@ private fun BigDecimal.convertFiatDecimalToFiatString(
             decimalFormatSymbols.apply {
                 decimalSeparator = monetarySeparators.decimal
                 monetaryDecimalSeparator = monetarySeparators.decimal
-                groupingSeparator = monetarySeparators.grouping
+                if (monetarySeparators.isGroupingValid()) {
+                    groupingSeparator = monetarySeparators.grouping
+                }
             }
         }
     }.format(this)

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/ZecStringExt.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/ZecStringExt.kt
@@ -16,6 +16,9 @@ object ZecStringExt {
      * Valid amounts: "" . | .123 | 123, | 123. | 123,456 | 123.456 | 123,456.789 | 123,456,789 | 123,456,789.123 | etc.
      * Invalid amounts: 123,, | 123,. | 123.. | ,123 | 123.456.789 | etc.
      *
+     * Note that this validation handles locales with the same grouping and decimal separators, which might be
+     * required in some rare cases.
+     *
      * @param context used for loading localized pattern from strings.xml
      * @param separators which consist of localized monetary separators
      * @param zecString to be validated
@@ -27,15 +30,18 @@ object ZecStringExt {
         separators: MonetarySeparators,
         zecString: String
     ): Boolean {
-        if (!context.getString(
+        return if (separators.isGroupingValid()) {
+            context.getString(
                 R.string.co_electriccoin_zcash_zec_amount_regex_continuous_filter,
                 separators.grouping,
                 separators.decimal
-            ).toRegex().matches(zecString) || !checkFor3Digits(separators, zecString)
-        ) {
-            return false
+            ).toRegex().matches(zecString) && checkFor3Digits(separators, zecString)
+        } else {
+            context.getString(
+                R.string.co_electriccoin_zcash_zec_amount_regex_continuous_no_grouping_filter,
+                separators.decimal
+            ).toRegex().matches(zecString)
         }
-        return true
     }
 
     /**
@@ -72,6 +78,9 @@ object ZecStringExt {
      * Valid amounts: 123 | .123 | 123. | 123, | 123.456 | 123,456 | 123,456.789 | 123,456,789 | 123,456,789.123 | etc.
      * Invalid amounts: "" | , | . | 123,, | 123,. | 123.. | ,123 | 123.456.789 | etc.
      *
+     * Note that this validation handles locales with the same grouping and decimal separators, which might be
+     * required in some rare cases.
+     *
      * @param context used for loading localized pattern from strings.xml
      * @param separators which consist of localized monetary separators
      * @param zecString to be validated
@@ -90,12 +99,17 @@ object ZecStringExt {
             return false
         }
 
-        return (
+        return if (separators.isGroupingValid()) {
             context.getString(
                 R.string.co_electriccoin_zcash_zec_amount_regex_confirm_filter,
                 separators.grouping,
                 separators.decimal
             ).toRegex().matches(zecString) && checkFor3Digits(separators, zecString)
-        )
+        } else {
+            context.getString(
+                R.string.co_electriccoin_zcash_zec_amount_regex_confirm_no_grouping_filter,
+                separators.decimal
+            ).toRegex().matches(zecString)
+        }
     }
 }

--- a/sdk-incubator-lib/src/main/res/values/strings-regex.xml
+++ b/sdk-incubator-lib/src/main/res/values/strings-regex.xml
@@ -1,4 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="co_electriccoin_zcash_zec_amount_regex_continuous_filter" formatted="true" tools:ignore="TypographyDashes">^([0-9]*([0-9]+([<xliff:g id="group" example=",">%1$s</xliff:g>]$|[<xliff:g id="group" example=",">%1$s</xliff:g>][0-9]+))*([<xliff:g id="dec" example=".">%2$s</xliff:g>]$|[<xliff:g id="dec" example=".">%2$s</xliff:g>][0-9]+)?)?$</string>
-    <string name="co_electriccoin_zcash_zec_amount_regex_confirm_filter" formatted="true" tools:ignore="TypographyDashes">^([0-9]{1,3}(?:[<xliff:g id="group" example=",">%1$s</xliff:g>]?[0-9]{3})*)*(?:[0-9]*[<xliff:g id="group" example=".">%2$s</xliff:g>][0-9]*)?$</string>
+    <string name="co_electriccoin_zcash_zec_amount_regex_continuous_no_grouping_filter" formatted="true" tools:ignore="TypographyDashes">^([0-9]*([<xliff:g id="dec" example=".">%1$s</xliff:g>]$|[<xliff:g id="dec" example=".">%1$s</xliff:g>][0-9]+)?)?$</string>
+
+    <string name="co_electriccoin_zcash_zec_amount_regex_confirm_filter" formatted="true" tools:ignore="TypographyDashes">^([0-9]{1,3}(?:[<xliff:g id="group" example=",">%1$s</xliff:g>]?[0-9]{3})*)*(?:[0-9]*[<xliff:g id="dec" example=".">%2$s</xliff:g>][0-9]*)?$</string>
+    <string name="co_electriccoin_zcash_zec_amount_regex_confirm_no_grouping_filter" formatted="true" tools:ignore="TypographyDashes">^[0-9]*(?:[<xliff:g id="dec" example=".">%1$s</xliff:g>][0-9]*)?$</string>
 </resources>


### PR DESCRIPTION
- Closes #1501
- Both ZecString and Zatoshi APIs now support MonetarySeparators with the same decimal and grouping characters by the grouping one omitting.
- Changelog update

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [x] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._