### PR TITLE
[#1539] Improve fetch UTXOs error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The fetch UTXOs logic reports `FetchUtxosException` to the wrapping `onProcessorErrorHandler` or 
+  `onCriticalErrorHandler` in case any error occurs 
+
+### Fixed
+- `Synchronizer.refreshUtxos(account: Account, since: BlockHeight)` now correctly uses the `since` parameter in the 
+  underlying logic and fetches UTXOs from that height
+
 ## [2.1.2] - 2024-07-16
 
 ### Added

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/internal/LightWalletClientImpl.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/internal/LightWalletClientImpl.kt
@@ -151,10 +151,10 @@ internal class LightWalletClientImpl private constructor(
             "${Constants.ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE_EMPTY} array of addresses contains invalid item." // NON-NLS
         }
 
-        val getUtxosBuilder = Service.GetAddressUtxosArg.newBuilder()
-
-        // Build the request with the different addresses
-        getUtxosBuilder.addAllAddresses(tAddresses)
+        val getUtxosBuilder = Service.GetAddressUtxosArg.newBuilder().apply {
+            addAllAddresses(tAddresses)
+            setStartHeight(startHeight.value)
+        }
 
         val request = getUtxosBuilder.build()
 

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/internal/LightWalletClientImpl.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/internal/LightWalletClientImpl.kt
@@ -151,10 +151,11 @@ internal class LightWalletClientImpl private constructor(
             "${Constants.ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE_EMPTY} array of addresses contains invalid item." // NON-NLS
         }
 
-        val getUtxosBuilder = Service.GetAddressUtxosArg.newBuilder().apply {
-            addAllAddresses(tAddresses)
-            setStartHeight(startHeight.value)
-        }
+        val getUtxosBuilder =
+            Service.GetAddressUtxosArg.newBuilder().apply {
+                addAllAddresses(tAddresses)
+                setStartHeight(startHeight.value)
+            }
 
         val request = getUtxosBuilder.build()
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -541,7 +541,7 @@ class SdkSynchronizer private constructor(
         val reason = if (scannedRange.isNullOrEmpty()) "it's been a while" else "new blocks were scanned"
 
         if (shouldRefresh) {
-            Twig.debug { "Triggering utxo refresh since $reason!" }
+            Twig.info { "Triggering utxo refresh since $reason!" }
             refreshUtxos(Account.DEFAULT)
 
             Twig.debug { "Triggering balance refresh since $reason!" }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
@@ -121,7 +121,6 @@ open class CompactBlockDownloader private constructor(val compactBlockRepository
                     }
                 }
             }
-
             null
         }
 


### PR DESCRIPTION
- Use omitted `startHeight` in `LightWalletClientImpl.fetchUtxos`
- Throw `FetchUtxosException` from `CompactBlockProcessor.refreshUtxos` and handle it in its callers as we do with the other networking requests. The exception is then delivered to the public API using `onProcessorErrorHandler` or `onCriticalErrorHandler`
- These changes also remove the 9 attempt limit in `refreshUtxos`
- Changelog update
- Closes #1539 
- Partly solves #683

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._