### PR TITLE
Remove `@CriticalNative` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Android 15 (SDK level 35) support added for 16 KB memory page size
-- The disposing logic of `TorClient` (the USD/ZEC rate fetching component) has been improved
+- The broken disposing logic `TorClient.freeTorRuntime` for Android SDK API level 27 has been fixed
 
 ## [2.2.3] - 2024-09-09
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorClient.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorClient.kt
@@ -57,7 +57,6 @@ class TorClient private constructor(
         @Throws(RuntimeException::class)
         private external fun createTorRuntime(torDir: String): Long
 
-        @CriticalNative
         @JvmStatic
         private external fun freeTorRuntime(nativeHandle: Long)
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorClient.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorClient.kt
@@ -3,7 +3,6 @@ package cash.z.ecc.android.sdk.internal.model
 import cash.z.ecc.android.sdk.internal.ext.existsSuspend
 import cash.z.ecc.android.sdk.internal.ext.mkdirsSuspend
 import cash.z.ecc.android.sdk.internal.jni.RustBackend
-import dalvik.annotation.optimization.CriticalNative
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -1985,7 +1985,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorClient_createTor
 
 /// Frees a Tor runtime.
 #[no_mangle]
-pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorClient_freeTorRuntime(ptr: jlong) {
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorClient_freeTorRuntime<'local>(
+    _: JNIEnv<'local>,
+    _: JClass<'local>,
+    ptr: jlong,
+) {
     let ptr = (ptr as usize) as *mut crate::tor::TorRuntime;
     if !ptr.is_null() {
         let s = unsafe { Box::from_raw(ptr) };


### PR DESCRIPTION
This was added to the `TorClient.dispose()` JNI pathway because that native coded did not require access to `JNIEnv` or `JClass`. However, it turns out that this annotation was only added in Android 8 for system usage [0], and was not CTS-tested public API until Android 14. For whatever reason, in API 27 (Android 8.1) the native method symbol can't be found, but in API 28 and above it can be.

The performance cost of regular JNI is no longer necessary to worry about given that we now keep a `TorClient` around long-term as part of `SdkSynchronizer`, so instead of doing anything complex to preserve it on API 28+ we just remove the `@CriticalNative` annotation and adjust the native method's signature to take (and ignore) the extra arguments.

Closes Electric-Coin-Company/zcash-android-wallet-sdk#1587.

[0]: https://developer.android.com/reference/dalvik/annotation/optimization/CriticalNative

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._