### PR TITLE
[#1595] Remove BlockHeight check

### DIFF
--- a/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/reorgs/InboundTxTests.kt
+++ b/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/reorgs/InboundTxTests.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import cash.z.ecc.android.sdk.darkside.test.DarksideTestCoordinator
 import cash.z.ecc.android.sdk.darkside.test.ScopedTest
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Test
@@ -22,7 +21,7 @@ class InboundTxTests : ScopedTest() {
 
     @Test
     fun testLatestHeight() {
-        validator.validateLatestHeight(BlockHeight.new(ZcashNetwork.Mainnet, targetTxBlock.value - 1))
+        validator.validateLatestHeight(BlockHeight.new(targetTxBlock.value - 1))
     }
 
     @Test
@@ -83,8 +82,8 @@ class InboundTxTests : ScopedTest() {
                 "https://raw.githubusercontent.com/zcash-hackworks/darksidewalletd-test-data/master/transactions/recv/71935e29127a7de0b96081f4c8a42a9c11584d83adedfaab414362a6f3d965cf.txt"
             )
 
-        private val firstBlock = BlockHeight.new(ZcashNetwork.Mainnet, 663150L)
-        private val targetTxBlock = BlockHeight.new(ZcashNetwork.Mainnet, 663188L)
+        private val firstBlock = BlockHeight.new(663150L)
+        private val targetTxBlock = BlockHeight.new(663188L)
         private const val LAST_BLOCK_HASH = "2fc7b4682f5ba6ba6f86e170b40f0aa9302e1d3becb2a6ee0db611ff87835e4a"
         private val sithLord = DarksideTestCoordinator()
         private val validator = sithLord.validator
@@ -98,7 +97,7 @@ class InboundTxTests : ScopedTest() {
             chainMaker
                 .resetBlocks(BLOCKS_URL, startHeight = firstBlock, tipHeight = targetTxBlock)
                 .stageEmptyBlocks(firstBlock + 1, 100)
-                .applyTipHeight(BlockHeight.new(ZcashNetwork.Mainnet, targetTxBlock.value - 1))
+                .applyTipHeight(BlockHeight.new(targetTxBlock.value - 1))
 
             // sithLord.await()
         }

--- a/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/DarksideTestCoordinator.kt
+++ b/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/DarksideTestCoordinator.kt
@@ -28,7 +28,7 @@ class DarksideTestCoordinator(val wallet: TestWallet) {
         endpoint: LightWalletEndpoint = LightWalletEndpoint.Darkside
     ) : this(TestWallet(seedPhrase, alias, network, endpoint, startHeight = startHeight))
 
-    private val targetHeight = BlockHeight.new(wallet.network, 663250)
+    private val targetHeight = BlockHeight.new(663250L)
     private val context = InstrumentationRegistry.getInstrumentation().context
 
     // dependencies: private
@@ -306,7 +306,7 @@ class DarksideTestCoordinator(val wallet: TestWallet) {
             "https://raw.githubusercontent.com/zcash-hackworks/darksidewalletd-test-data/master/basic-reorg/after-small-reorg.txt"
         private const val LARGE_REORG =
             "https://raw.githubusercontent.com/zcash-hackworks/darksidewalletd-test-data/master/basic-reorg/after-large-reorg.txt"
-        private val DEFAULT_START_HEIGHT = BlockHeight.new(ZcashNetwork.Mainnet, 663150)
+        private val DEFAULT_START_HEIGHT = BlockHeight.new(663150L)
         private const val DEFAULT_SEED_PHRASE =
             "still champion voice habit trend flight survey between bitter process artefact blind carbon truly" +
                 " provide dizzy crush flush breeze blouse charge solid fish spread"

--- a/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/TestWallet.kt
+++ b/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/TestWallet.kt
@@ -123,7 +123,7 @@ class TestWallet(
     }
 
     suspend fun shieldFunds(): TestWallet {
-        synchronizer.refreshUtxos(Account.DEFAULT, BlockHeight.new(ZcashNetwork.Mainnet, 935000)).let { count ->
+        synchronizer.refreshUtxos(Account.DEFAULT, BlockHeight.new(935000L)).let { count ->
             Twig.debug { "FOUND $count new UTXOs" }
         }
 
@@ -163,46 +163,33 @@ class TestWallet(
             "column rhythm acoustic gym cost fit keen maze fence seed mail medal shrimp tell relief clip" +
                 " cannon foster soldier shallow refuse lunar parrot banana",
             BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_355_928
+                1_355_928L
             ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_000_000L)
         ),
         SAMPLE_WALLET(
             "input frown warm senior anxiety abuse yard prefer churn reject people glimpse govern glory" +
                 " crumble swallow verb laptop switch trophy inform friend permit purpose",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_330_190
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_330_190L),
+            BlockHeight.new(1_000_000L)
         ),
         DEV_WALLET(
             "still champion voice habit trend flight survey between bitter process artefact blind carbon" +
                 " truly provide dizzy crush flush breeze blouse charge solid fish spread",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_000_000
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 991645)
+            BlockHeight.new(1_000_000L),
+            BlockHeight.new(991645L)
         ),
         ALICE(
             "quantum whisper lion route fury lunar pelican image job client hundred sauce chimney barely" +
                 " life cliff spirit admit weekend message recipe trumpet impact kitten",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_330_190
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_330_190L),
+            BlockHeight.new(1_000_000L)
         ),
         BOB(
             "canvas wine sugar acquire garment spy tongue odor hole cage year habit bullet make label" +
                 " human unit option top calm neutral try vocal arena",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_330_190
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_330_190L),
+            BlockHeight.new(1_000_000L)
         )
     }
 }

--- a/demo-app/src/androidTest/java/cash/z/wallet/sdk/sample/demoapp/SampleCodeTest.kt
+++ b/demo-app/src/androidTest/java/cash/z/wallet/sdk/sample/demoapp/SampleCodeTest.kt
@@ -108,17 +108,9 @@ class SampleCodeTest {
             @Suppress("ktlint:standard:multiline-expression-wrapping")
             val blockRange =
                 BlockHeightUnsafe(
-                    BlockHeight.new(
-                        ZcashNetwork.Mainnet,
-                        500_000
-                    ).value
+                    BlockHeight.new(500_000L).value
                 )..BlockHeightUnsafe(
-                    (
-                        BlockHeight.new(
-                            ZcashNetwork.Mainnet,
-                            500_009
-                        ).value
-                    )
+                    (BlockHeight.new(500_009L).value)
                 )
 
             val lightWalletClient = LightWalletClient.new(context, lightwalletdHost)

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/SharedViewModel.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/SharedViewModel.kt
@@ -82,7 +82,7 @@ class SharedViewModel(application: Application) : AndroidViewModel(application) 
                             seed = seedBytes,
                             birthday =
                                 if (BenchmarkingExt.isBenchmarking()) {
-                                    BlockHeight.new(ZcashNetwork.Mainnet, BenchmarkingBlockRangeFixture.new().start)
+                                    BlockHeight.new(BenchmarkingBlockRangeFixture.new().start)
                                 } else {
                                     birthdayHeight.value
                                 },

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/listutxos/ListUtxosFragment.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/listutxos/ListUtxosFragment.kt
@@ -1,6 +1,5 @@
 package cash.z.ecc.android.sdk.demoapp.demos.listutxos
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -57,7 +56,7 @@ class ListUtxosFragment : BaseDemoFragment<FragmentListUtxosBinding>() {
         binding.inputRangeStart.setText(
             ZcashNetwork.fromResources(requireApplicationContext()).saplingActivationHeight.toString()
         )
-        binding.inputRangeEnd.setText(getUxtoEndHeight(requireApplicationContext()).value.toString())
+        binding.inputRangeEnd.setText(getUxtoEndHeight().value.toString())
 
         binding.buttonLoad.setOnClickListener {
             mainActivity()?.hideKeyboard()
@@ -237,7 +236,7 @@ class ListUtxosFragment : BaseDemoFragment<FragmentListUtxosBinding>() {
     }
 
     @Suppress("MagicNumber")
-    private fun getUxtoEndHeight(context: Context): BlockHeight {
-        return BlockHeight.new(ZcashNetwork.fromResources(context), 968085L)
+    private fun getUxtoEndHeight(): BlockHeight {
+        return BlockHeight.new(968085L)
     }
 }

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/ui/screen/seed/view/ConfigureSeedView.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/ui/screen/seed/view/ConfigureSeedView.kt
@@ -168,7 +168,7 @@ private fun RestoreWalletSection(
 
                 val blockHeight =
                     walletBirthdayString.toLongOrNull()?.let { blockHeight ->
-                        BlockHeight.new(zcashNetwork, blockHeight)
+                        BlockHeight.new(blockHeight)
                     } ?: zcashNetwork.saplingActivationHeight // fallback to last known valid value
 
                 val wallet =

--- a/sdk-incubator-lib/src/androidTest/kotlin/cash/z/ecc/android/sdk/fixture/PersistableWalletFixture.kt
+++ b/sdk-incubator-lib/src/androidTest/kotlin/cash/z/ecc/android/sdk/fixture/PersistableWalletFixture.kt
@@ -15,7 +15,7 @@ object PersistableWalletFixture {
 
     // These came from the mainnet 1500000.json file
     @Suppress("MagicNumber")
-    val BIRTHDAY = BlockHeight.new(ZcashNetwork.Mainnet, 1500000L)
+    val BIRTHDAY = BlockHeight.new(1500000L)
 
     val SEED_PHRASE = SeedPhraseFixture.new()
 

--- a/sdk-incubator-lib/src/androidTest/kotlin/cash/z/ecc/android/sdk/model/PersistableWalletTest.kt
+++ b/sdk-incubator-lib/src/androidTest/kotlin/cash/z/ecc/android/sdk/model/PersistableWalletTest.kt
@@ -90,7 +90,7 @@ class PersistableWalletTest {
         val json = PersistableWalletFixture.new().toJson()
         assertEquals(
             PersistableWalletFixture.BIRTHDAY.value,
-            PersistableWallet.getBirthday(json, PersistableWalletFixture.NETWORK)!!.value
+            PersistableWallet.getBirthday(json)!!.value
         )
     }
 

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
@@ -101,10 +101,10 @@ sealed class WalletFixture {
         fun lastKnownBirthday(zcashNetwork: ZcashNetwork) =
             when (zcashNetwork.id) {
                 ZcashNetwork.ID_TESTNET -> {
-                    BlockHeight.new(zcashNetwork, 2170000L)
+                    BlockHeight.new(2170000L)
                 }
                 ZcashNetwork.ID_MAINNET -> {
-                    BlockHeight.new(zcashNetwork, 1935000L)
+                    BlockHeight.new(1935000L)
                 }
                 else -> error("Unknown network $zcashNetwork")
             }

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/PersistableWallet.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/model/PersistableWallet.kt
@@ -85,7 +85,7 @@ data class PersistableWallet(
         fun from(jsonObject: JSONObject): PersistableWallet {
             // Common parameters
             val network = getNetwork(jsonObject)
-            val birthday = getBirthday(jsonObject, network)
+            val birthday = getBirthday(jsonObject)
             val seedPhrase = getSeedPhrase(jsonObject)
             // From version 2
             val endpoint: LightWalletEndpoint
@@ -124,13 +124,10 @@ data class PersistableWallet(
             return ZcashNetwork.from(networkId)
         }
 
-        internal fun getBirthday(
-            jsonObject: JSONObject,
-            network: ZcashNetwork
-        ): BlockHeight? {
+        internal fun getBirthday(jsonObject: JSONObject): BlockHeight? {
             return if (jsonObject.has(KEY_BIRTHDAY)) {
                 val birthdayBlockHeightLong = jsonObject.getLong(KEY_BIRTHDAY)
-                BlockHeight.new(network, birthdayBlockHeightLong)
+                BlockHeight.new(birthdayBlockHeightLong)
             } else {
                 null
             }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/AssetTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/AssetTest.kt
@@ -86,7 +86,7 @@ class AssetTest {
 
             assertEquals(
                 "File: ${it.filename}",
-                CheckpointTool.checkpointHeightFromFilename(network, it.filename).value,
+                CheckpointTool.checkpointHeightFromFilename(it.filename).value,
                 jsonObject.getLong("height")
             )
 

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/integration/TestnetIntegrationTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/integration/TestnetIntegrationTest.kt
@@ -152,7 +152,7 @@ class TestnetIntegrationTest : ScopedTest() {
                     lightWalletEndpoint =
                     lightWalletEndpoint,
                     seed = seed,
-                    birthday = BlockHeight.new(ZcashNetwork.Testnet, BIRTHDAY_HEIGHT),
+                    birthday = BlockHeight.new(BIRTHDAY_HEIGHT),
                     // Using existing wallet init mode as simplification for the test
                     walletInitMode = WalletInitMode.ExistingWallet
                 )

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/storage/block/FileCompactBlockRepositoryTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/storage/block/FileCompactBlockRepositoryTest.kt
@@ -7,7 +7,6 @@ import cash.z.ecc.android.sdk.internal.ext.existsSuspend
 import cash.z.ecc.android.sdk.internal.ext.listSuspend
 import cash.z.ecc.android.sdk.internal.ext.mkdirsSuspend
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import cash.z.ecc.fixture.FakeRustBackendFixture
 import cash.z.ecc.fixture.FilePathFixture
 import co.electriccoin.lightwallet.client.fixture.ListOfCompactBlocksFixture
@@ -76,7 +75,6 @@ class FileCompactBlockRepositoryTest {
     @Test
     fun findCompactBlockTest() =
         runTest {
-            val network = ZcashNetwork.Testnet
             val rustBackend = FakeRustBackendFixture().new()
             val blockRepository =
                 getMockedFileCompactBlockRepository(
@@ -90,17 +88,14 @@ class FileCompactBlockRepositoryTest {
 
             val firstPersistedBlock =
                 blockRepository.findCompactBlock(
-                    BlockHeight.new(network, blocks.first().height)
+                    BlockHeight.new(blockHeight = blocks.first().height)
                 )
             val lastPersistedBlock =
                 blockRepository.findCompactBlock(
-                    BlockHeight.new(network, blocks.last().height)
+                    BlockHeight.new(blockHeight = blocks.last().height)
                 )
             val notPersistedBlockHeight =
-                BlockHeight.new(
-                    network,
-                    blockHeight = blocks.last().height + 1
-                )
+                BlockHeight.new(blockHeight = blocks.last().height + 1)
 
             assertNotNull(firstPersistedBlock)
             assertNotNull(lastPersistedBlock)

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/jni/BranchIdTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/jni/BranchIdTest.kt
@@ -84,28 +84,28 @@ class BranchIdTest internal constructor(
                 // Mainnet Cases
                 arrayOf(
                     "Sapling",
-                    BlockHeight.new(ZcashNetwork.Mainnet, 419_200),
+                    BlockHeight.new(419_200L),
                     1991772603L,
                     "76b809bb",
                     mainnetBackend
                 ),
                 arrayOf(
                     "Blossom",
-                    BlockHeight.new(ZcashNetwork.Mainnet, 653_600),
+                    BlockHeight.new(653_600L),
                     733220448L,
                     "2bb40e60",
                     mainnetBackend
                 ),
                 arrayOf(
                     "Heartwood",
-                    BlockHeight.new(ZcashNetwork.Mainnet, 903_000),
+                    BlockHeight.new(903_000L),
                     4122551051L,
                     "f5b9230b",
                     mainnetBackend
                 ),
                 arrayOf(
                     "Canopy",
-                    BlockHeight.new(ZcashNetwork.Mainnet, 1_046_400),
+                    BlockHeight.new(1_046_400L),
                     3925833126L,
                     "e9ff75a6",
                     mainnetBackend
@@ -113,28 +113,28 @@ class BranchIdTest internal constructor(
                 // Testnet Cases
                 arrayOf(
                     "Sapling",
-                    BlockHeight.new(ZcashNetwork.Testnet, 280_000),
+                    BlockHeight.new(280_000L),
                     1991772603L,
                     "76b809bb",
                     testnetBackend
                 ),
                 arrayOf(
                     "Blossom",
-                    BlockHeight.new(ZcashNetwork.Testnet, 584_000),
+                    BlockHeight.new(584_000L),
                     733220448L,
                     "2bb40e60",
                     testnetBackend
                 ),
                 arrayOf(
                     "Heartwood",
-                    BlockHeight.new(ZcashNetwork.Testnet, 903_800),
+                    BlockHeight.new(903_800L),
                     4122551051L,
                     "f5b9230b",
                     testnetBackend
                 ),
                 arrayOf(
                     "Canopy",
-                    BlockHeight.new(ZcashNetwork.Testnet, 1_028_500),
+                    BlockHeight.new(1_028_500L),
                     3925833126L,
                     "e9ff75a6",
                     testnetBackend

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/sample/TransparentRestoreSample.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/sample/TransparentRestoreSample.kt
@@ -75,7 +75,7 @@ class TransparentRestoreSample {
 //        wallet.rewindToHeight(1343500).join(45_000)
             val wallet = TestWallet(TestWallet.Backups.SAMPLE_WALLET, alias = "WalletC")
 //        wallet.sync().rewindToHeight(1339178).join(10000)
-            wallet.sync().rewindToHeight(BlockHeight.new(ZcashNetwork.Testnet, 1339178)).send(
+            wallet.sync().rewindToHeight(BlockHeight.new(1339178L)).send(
                 "ztestsapling17zazsl8rryl8kjaqxnr2r29rw9d9a2mud37ugapm0s8gmyv0ue43h9lqwmhdsp3nu9dazeqfs6l",
                 "is send broken?"
             ).join(5)
@@ -94,10 +94,7 @@ class TransparentRestoreSample {
                     "tmpabc",
                     ZcashNetwork.Testnet,
                     startHeight =
-                        BlockHeight.new(
-                            ZcashNetwork.Testnet,
-                            1330190
-                        )
+                        BlockHeight.new(1330190L)
                 )
 //        val wallet1 = SimpleWallet(WALLET0_PHRASE, "Wallet1")
 
@@ -128,10 +125,7 @@ class TransparentRestoreSample {
                     "WalletC",
                     ZcashNetwork.Testnet,
                     startHeight =
-                        BlockHeight.new(
-                            ZcashNetwork.Testnet,
-                            1330190
-                        )
+                        BlockHeight.new(1330190L)
                 )
             //        val job = walletA.walletScope.launch {
             //            walletA.sync()
@@ -147,7 +141,7 @@ class TransparentRestoreSample {
             // send z->t
             //        walletA.send(TX_VALUE, walletA.transparentAddress, "${TransparentRestoreSample::class.java.simpleName} z->t")
 
-            walletSandbox.rewindToHeight(BlockHeight.new(ZcashNetwork.Testnet, 1339178))
+            walletSandbox.rewindToHeight(BlockHeight.new(1339178L))
             delay(500)
             //        walletB.sync()
             // rewind database B to height then rescan

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/tool/CheckpointToolTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/tool/CheckpointToolTest.kt
@@ -18,8 +18,8 @@ class CheckpointToolTest {
     @SmallTest
     fun birthday_height_from_filename() {
         assertEquals(
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_230_000),
-            CheckpointTool.checkpointHeightFromFilename(ZcashNetwork.Mainnet, "1230000.json")
+            BlockHeight.new(1_230_000L),
+            CheckpointTool.checkpointHeightFromFilename("1230000.json")
         )
     }
 

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/BalancePrinterUtil.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/BalancePrinterUtil.kt
@@ -27,7 +27,7 @@ import org.junit.Test
 class BalancePrinterUtil {
     private val network = ZcashNetwork.Mainnet
     private val downloadBatchSize = 9_000
-    private val birthdayHeight = BlockHeight.new(network, 523240)
+    private val birthdayHeight = BlockHeight.new(523240L)
 
     private val mnemonics = SimpleMnemonics()
     private val context = InstrumentationRegistry.getInstrumentation().context

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/DataDbScannerUtil.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/DataDbScannerUtil.kt
@@ -70,11 +70,7 @@ class DataDbScannerUtil {
                 ZcashNetwork.Mainnet,
                 lightWalletEndpoint = LightWalletEndpointFixture.newEndpointForNetwork(ZcashNetwork.Mainnet),
                 seed = byteArrayOf(),
-                birthday =
-                    BlockHeight.new(
-                        ZcashNetwork.Mainnet,
-                        birthdayHeight
-                    ),
+                birthday = BlockHeight.new(birthdayHeight),
                 // Using existing wallet init mode as simplification for the test
                 walletInitMode = WalletInitMode.ExistingWallet
             )

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/TestWallet.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/TestWallet.kt
@@ -124,7 +124,7 @@ class TestWallet(
     }
 
     suspend fun shieldFunds(): TestWallet {
-        synchronizer.refreshUtxos(Account.DEFAULT, BlockHeight.new(ZcashNetwork.Mainnet, 935000)).let { count ->
+        synchronizer.refreshUtxos(Account.DEFAULT, BlockHeight.new(935000L)).let { count ->
             Twig.debug { "FOUND $count new UTXOs" }
         }
 
@@ -168,47 +168,34 @@ class TestWallet(
         DEFAULT(
             "column rhythm acoustic gym cost fit keen maze fence seed mail medal shrimp tell relief clip" +
                 " cannon foster soldier shallow refuse lunar parrot banana",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_355_928
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_355_928L),
+            BlockHeight.new(1_000_000L)
         ),
         SAMPLE_WALLET(
             "input frown warm senior anxiety abuse yard prefer churn reject people glimpse govern glory" +
                 " crumble swallow verb laptop switch trophy inform friend permit purpose",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_330_190
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_330_190L),
+            BlockHeight.new(1_000_000L)
         ),
         DEV_WALLET(
             "still champion voice habit trend flight survey between bitter process artefact blind carbon" +
                 " truly provide dizzy crush flush breeze blouse charge solid fish spread",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_000_000
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 991645)
+            BlockHeight.new(1_000_000L),
+            BlockHeight.new(991645L)
         ),
         ALICE(
             "quantum whisper lion route fury lunar pelican image job client hundred sauce chimney barely" +
                 " life cliff spirit admit weekend message recipe trumpet impact kitten",
-            BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_330_190
-            ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_330_190L),
+            BlockHeight.new(1_000_000L)
         ),
         BOB(
             "canvas wine sugar acquire garment spy tongue odor hole cage year habit bullet make label human" +
                 " unit option top calm neutral try vocal arena",
             BlockHeight.new(
-                ZcashNetwork.Testnet,
-                1_330_190
+                1_330_190L
             ),
-            BlockHeight.new(ZcashNetwork.Mainnet, 1_000_000)
+            BlockHeight.new(1_000_000L)
         )
     }
 }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/TransactionCounterUtil.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/TransactionCounterUtil.kt
@@ -26,15 +26,9 @@ class TransactionCounterUtil {
         @Suppress("ktlint:standard:multiline-expression-wrapping")
         lightWalletClient.getBlockRange(
             BlockHeightUnsafe.from(
-                BlockHeight.new(
-                    ZcashNetwork.Mainnet,
-                    900_000
-                )
+                BlockHeight.new(900_000L)
             )..BlockHeightUnsafe.from(
-                BlockHeight.new(
-                    ZcashNetwork.Mainnet,
-                    910_000
-                )
+                BlockHeight.new(910_000L)
             )
         )
         /*
@@ -63,15 +57,9 @@ class TransactionCounterUtil {
         @Suppress("ktlint:standard:multiline-expression-wrapping")
         lightWalletClient.getBlockRange(
             BlockHeightUnsafe.from(
-                BlockHeight.new(
-                    ZcashNetwork.Mainnet,
-                    900_000
-                )
+                BlockHeight.new(900_000L)
             )..BlockHeightUnsafe.from(
-                BlockHeight.new(
-                    ZcashNetwork.Mainnet,
-                    950_000
-                )
+                BlockHeight.new(950_000L)
             )
         )
         /*

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/fixture/CheckpointFixture.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/fixture/CheckpointFixture.kt
@@ -16,7 +16,7 @@ object CheckpointFixture {
     val NETWORK = ZcashNetwork.Mainnet
 
     // These came from the mainnet 1700000.json file
-    val HEIGHT = BlockHeight.new(ZcashNetwork.Mainnet, 1700000L)
+    val HEIGHT = BlockHeight.new(1700000L)
     const val HASH = "0000000000f430793e0c6381b40b47ed77b0ed76d21c2c667acdfe7747a8ed5b"
     const val EPOCH_SECONDS = 1654991544L
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -831,7 +831,7 @@ class SdkSynchronizer private constructor(
             ) {
                 is Response.Success -> {
                     Twig.info { "Chain tip for validate consensus branch action fetched: ${response.result.value}" }
-                    runCatching { response.result.toBlockHeight(network) }.getOrNull()
+                    runCatching { response.result.toBlockHeight() }.getOrNull()
                 }
 
                 is Response.Failure -> {
@@ -891,7 +891,7 @@ class SdkSynchronizer private constructor(
 
         // Check sapling activation height
         runCatching {
-            val remoteSaplingActivationHeight = remoteInfo.saplingActivationHeightUnsafe.toBlockHeight(network)
+            val remoteSaplingActivationHeight = remoteInfo.saplingActivationHeightUnsafe.toBlockHeight()
             if (network.saplingActivationHeight != remoteSaplingActivationHeight) {
                 return ServerValidation.InValid(
                     CompactBlockProcessorException.MismatchedSaplingActivationHeight(
@@ -907,7 +907,7 @@ class SdkSynchronizer private constructor(
         val currentChainTip =
             when (val response = lightWalletClient.getLatestBlockHeight()) {
                 is Response.Success -> {
-                    runCatching { response.result.toBlockHeight(network) }.getOrElse {
+                    runCatching { response.result.toBlockHeight() }.getOrElse {
                         return ServerValidation.InValid(it)
                     }
                 }
@@ -986,7 +986,6 @@ internal object DefaultSynchronizerFactory {
         context: Context,
         rustBackend: TypesafeBackend,
         databaseFile: File,
-        zcashNetwork: ZcashNetwork,
         checkpoint: Checkpoint,
         seed: ByteArray?,
         numberOfAccounts: Int,
@@ -997,7 +996,6 @@ internal object DefaultSynchronizerFactory {
                 context,
                 rustBackend,
                 databaseFile,
-                zcashNetwork,
                 checkpoint,
                 seed,
                 numberOfAccounts,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -650,7 +650,7 @@ interface Synchronizer {
                         when (val response = downloader.getLatestBlockHeight()) {
                             is Response.Success -> {
                                 Twig.info { "Chain tip for recovery until param fetched: ${response.result.value}" }
-                                runCatching { response.result.toBlockHeight(zcashNetwork) }.getOrNull()
+                                runCatching { response.result.toBlockHeight() }.getOrNull()
                             }
                             is Response.Failure -> {
                                 Twig.error {
@@ -670,7 +670,6 @@ interface Synchronizer {
                     context = applicationContext,
                     rustBackend = backend,
                     databaseFile = coordinator.dataDbFile(zcashNetwork, alias),
-                    zcashNetwork = zcashNetwork,
                     checkpoint = loadedCheckpoint,
                     seed = seed,
                     numberOfAccounts = Derivation.DEFAULT_NUMBER_OF_ACCOUNTS,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/FastestServerFetcher.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/FastestServerFetcher.kt
@@ -144,7 +144,7 @@ internal class FastestServerFetcher(
 
         // Check sapling activation height
         runCatching {
-            val remoteSaplingActivationHeight = remoteInfo.saplingActivationHeightUnsafe.toBlockHeight(network)
+            val remoteSaplingActivationHeight = remoteInfo.saplingActivationHeightUnsafe.toBlockHeight()
             if (network.saplingActivationHeight != remoteSaplingActivationHeight) {
                 logRuledOut("invalid saplingActivationHeight")
                 return null
@@ -160,7 +160,7 @@ internal class FastestServerFetcher(
                 currentChainTip =
                     when (val response = lightWalletClient.getLatestBlockHeight()) {
                         is Response.Success -> {
-                            runCatching { response.result.toBlockHeight(network) }.getOrElse {
+                            runCatching { response.result.toBlockHeight() }.getOrElse {
                                 logRuledOut("toBlockHeight failed", it)
                                 return null
                             }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -99,10 +99,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
     }
 
     override suspend fun getNearestRewindHeight(height: BlockHeight): BlockHeight {
-        return BlockHeight.new(
-            ZcashNetwork.from(backend.networkId),
-            backend.getNearestRewindHeight(height.value)
-        )
+        return BlockHeight.new(backend.getNearestRewindHeight(height.value))
     }
 
     override suspend fun rewindToHeight(height: BlockHeight) {
@@ -111,10 +108,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
 
     override suspend fun getLatestCacheHeight(): BlockHeight? {
         return backend.getLatestCacheHeight()?.let {
-            BlockHeight.new(
-                ZcashNetwork.from(backend.networkId),
-                it
-            )
+            BlockHeight.new(it)
         }
     }
 
@@ -204,10 +198,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
     override suspend fun getFullyScannedHeight(): BlockHeight? {
         return runCatching {
             backend.getFullyScannedHeight()?.let {
-                BlockHeight.new(
-                    ZcashNetwork.from(backend.networkId),
-                    it
-                )
+                BlockHeight.new(it)
             }
         }.onFailure {
             Twig.warn(it) { "Currently unable to get fully scanned height" }
@@ -217,10 +208,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
     override suspend fun getMaxScannedHeight(): BlockHeight? {
         return runCatching {
             backend.getMaxScannedHeight()?.let {
-                BlockHeight.new(
-                    ZcashNetwork.from(backend.networkId),
-                    it
-                )
+                BlockHeight.new(it)
             }
         }.onFailure {
             Twig.warn(it) { "Currently unable to get max scanned height" }
@@ -231,14 +219,11 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
         fromHeight: BlockHeight,
         fromState: TreeState,
         limit: Long
-    ): ScanSummary = ScanSummary.new(backend.scanBlocks(fromHeight.value, fromState.encoded, limit), network)
+    ): ScanSummary = ScanSummary.new(backend.scanBlocks(fromHeight.value, fromState.encoded, limit))
 
     override suspend fun transactionDataRequests(): List<TransactionDataRequest> =
         backend.transactionDataRequests().map { jniRequest ->
-            TransactionDataRequest.new(
-                jniRequest,
-                network
-            )
+            TransactionDataRequest.new(jniRequest)
         }
 
     override suspend fun getWalletSummary(): WalletSummary? =
@@ -248,10 +233,7 @@ internal class TypesafeBackendImpl(private val backend: Backend) : TypesafeBacke
 
     override suspend fun suggestScanRanges(): List<ScanRange> =
         backend.suggestScanRanges().map { jniScanRange ->
-            ScanRange.new(
-                jniScanRange,
-                network
-            )
+            ScanRange.new(jniScanRange)
         }
 
     override suspend fun decryptAndStoreTransaction(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/AllTransactionView.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/AllTransactionView.kt
@@ -10,14 +10,12 @@ import cash.z.ecc.android.sdk.internal.model.DbTransactionOverview
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.Zatoshi
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import java.util.Locale
 import kotlin.math.absoluteValue
 
 internal class AllTransactionView(
-    private val zcashNetwork: ZcashNetwork,
     private val sqliteDatabase: SupportSQLiteDatabase
 ) {
     companion object {
@@ -121,7 +119,7 @@ internal class AllTransactionView(
                 rawId = FirstClassByteArray(cursor.getBlob(rawTransactionIdIndex)),
                 minedHeight =
                     cursor.getLongOrNull(minedHeightColumnIndex)?.let {
-                        BlockHeight.new(zcashNetwork, it)
+                        BlockHeight.new(it)
                     },
                 expiryHeight =
                     cursor.getLongOrNull(expiryHeightIndex)?.let {
@@ -129,7 +127,7 @@ internal class AllTransactionView(
                         if (0L == it) {
                             null
                         } else {
-                            BlockHeight.new(zcashNetwork, it)
+                            BlockHeight.new(it)
                         }
                     },
                 index = cursor.getLongOrNull(transactionIndexColumnIndex),
@@ -192,7 +190,7 @@ internal class AllTransactionView(
             ).firstOrNull()
 
         return if (heightLong != null) {
-            BlockHeight.new(zcashNetwork, heightLong)
+            BlockHeight.new(heightLong)
         } else {
             null
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DerivedDataDb.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DerivedDataDb.kt
@@ -9,21 +9,19 @@ import cash.z.ecc.android.sdk.internal.TypesafeBackend
 import cash.z.ecc.android.sdk.internal.db.ReadOnlySupportSqliteOpenHelper
 import cash.z.ecc.android.sdk.internal.model.Checkpoint
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import kotlinx.coroutines.withContext
 import java.io.File
 
 internal class DerivedDataDb private constructor(
-    zcashNetwork: ZcashNetwork,
     private val sqliteDatabase: SupportSQLiteDatabase
 ) {
     val accountTable = AccountTable(sqliteDatabase)
 
-    val transactionTable = TransactionTable(zcashNetwork, sqliteDatabase)
+    val transactionTable = TransactionTable(sqliteDatabase)
 
-    val allTransactionView = AllTransactionView(zcashNetwork, sqliteDatabase)
+    val allTransactionView = AllTransactionView(sqliteDatabase)
 
-    val txOutputsView = TxOutputsView(zcashNetwork, sqliteDatabase)
+    val txOutputsView = TxOutputsView(sqliteDatabase)
 
     suspend fun close() =
         withContext(SdkDispatchers.DATABASE_IO) {
@@ -45,7 +43,6 @@ internal class DerivedDataDb private constructor(
             context: Context,
             backend: TypesafeBackend,
             databaseFile: File,
-            zcashNetwork: ZcashNetwork,
             checkpoint: Checkpoint,
             seed: ByteArray?,
             numberOfAccounts: Int,
@@ -63,7 +60,7 @@ internal class DerivedDataDb private constructor(
                     DATABASE_VERSION
                 )
 
-            val dataDb = DerivedDataDb(zcashNetwork, database)
+            val dataDb = DerivedDataDb(database)
 
             // If a seed is provided, fill in the accounts.
             seed?.let { checkedSeed ->

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TransactionTable.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TransactionTable.kt
@@ -5,13 +5,11 @@ import cash.z.ecc.android.sdk.internal.db.queryAndMap
 import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import java.util.Locale
 
 internal class TransactionTable(
-    private val zcashNetwork: ZcashNetwork,
     private val sqliteDatabase: SupportSQLiteDatabase
 ) {
     companion object {
@@ -84,7 +82,7 @@ internal class TransactionTable(
                 if (it.isNull(heightIndex)) {
                     null
                 } else {
-                    BlockHeight.new(zcashNetwork, it.getLong(heightIndex))
+                    BlockHeight.new(it.getLong(heightIndex))
                 }
 
             EncodedTransaction(
@@ -103,7 +101,7 @@ internal class TransactionTable(
             selectionArgs = arrayOf(rawTransactionId)
         ) {
             val blockIndex = it.getColumnIndexOrThrow(TransactionTableDefinition.COLUMN_INTEGER_BLOCK)
-            BlockHeight.new(zcashNetwork, it.getLong(blockIndex))
+            BlockHeight.new(it.getLong(blockIndex))
         }.firstOrNull()
     }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TxOutputsView.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TxOutputsView.kt
@@ -6,14 +6,9 @@ import cash.z.ecc.android.sdk.internal.model.OutputProperties
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.TransactionRecipient
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import java.util.Locale
 
-internal class TxOutputsView(
-    @Suppress("UnusedPrivateMember")
-    private val zcashNetwork: ZcashNetwork,
-    private val sqliteDatabase: SupportSQLiteDatabase
-) {
+internal class TxOutputsView(private val sqliteDatabase: SupportSQLiteDatabase) {
     companion object {
         private val ORDER_BY =
             String.format(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ScanRange.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ScanRange.kt
@@ -1,7 +1,6 @@
 package cash.z.ecc.android.sdk.internal.model
 
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 
 internal data class ScanRange(
     val range: ClosedRange<BlockHeight>,
@@ -24,13 +23,9 @@ internal data class ScanRange(
          *  Note that this function subtracts 1 from [JniScanRange.endHeight] as the rest of the logic works with
          *  [ClosedRange] and the endHeight is exclusive.
          */
-        fun new(
-            jni: JniScanRange,
-            zcashNetwork: ZcashNetwork
-        ): ScanRange {
+        fun new(jni: JniScanRange): ScanRange {
             return ScanRange(
-                range =
-                    BlockHeight.new(zcashNetwork, jni.startHeight)..(BlockHeight.new(zcashNetwork, jni.endHeight) - 1),
+                range = BlockHeight.new(jni.startHeight)..(BlockHeight.new(jni.endHeight) - 1),
                 priority = jni.priority
             )
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ScanSummary.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ScanSummary.kt
@@ -1,7 +1,6 @@
 package cash.z.ecc.android.sdk.internal.model
 
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 
 internal data class ScanSummary(
     val scannedRange: ClosedRange<BlockHeight>,
@@ -14,21 +13,9 @@ internal data class ScanSummary(
          *  as the rest of the logic works with [ClosedRange] and the endHeight
          *  is exclusive.
          */
-        fun new(
-            jni: JniScanSummary,
-            zcashNetwork: ZcashNetwork
-        ): ScanSummary {
+        fun new(jni: JniScanSummary): ScanSummary {
             return ScanSummary(
-                scannedRange =
-                    BlockHeight.new(
-                        zcashNetwork,
-                        jni.startHeight
-                    )..(
-                        BlockHeight.new(
-                            zcashNetwork,
-                            jni.endHeight
-                        ) - 1
-                    ),
+                scannedRange = BlockHeight.new(jni.startHeight)..(BlockHeight.new(jni.endHeight) - 1),
                 spentSaplingNoteCount = jni.spentSaplingNoteCount,
                 receivedSaplingNoteCount = jni.receivedSaplingNoteCount
             )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/SubtreeRoot.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/SubtreeRoot.kt
@@ -1,7 +1,6 @@
 package cash.z.ecc.android.sdk.internal.model
 
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.lightwallet.client.model.SubtreeRootUnsafe
 
 internal data class SubtreeRoot(
@@ -32,14 +31,11 @@ internal data class SubtreeRoot(
     }
 
     companion object {
-        fun new(
-            unsafe: SubtreeRootUnsafe,
-            zcashNetwork: ZcashNetwork
-        ): SubtreeRoot {
+        fun new(unsafe: SubtreeRootUnsafe): SubtreeRoot {
             return SubtreeRoot(
                 rootHash = unsafe.rootHash,
                 completingBlockHash = unsafe.completingBlockHash,
-                completingBlockHeight = BlockHeight.new(zcashNetwork, unsafe.completingBlockHeight.value)
+                completingBlockHeight = BlockHeight.new(unsafe.completingBlockHeight.value)
             )
         }
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TransactionDataRequest.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TransactionDataRequest.kt
@@ -3,7 +3,6 @@ package cash.z.ecc.android.sdk.internal.model
 import cash.z.ecc.android.sdk.exception.SdkException
 import cash.z.ecc.android.sdk.internal.ext.toHexReversed
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class.
@@ -36,21 +35,18 @@ sealed interface TransactionDataRequest {
     }
 
     companion object {
-        fun new(
-            jni: JniTransactionDataRequest,
-            zcashNetwork: ZcashNetwork
-        ): TransactionDataRequest {
+        fun new(jni: JniTransactionDataRequest): TransactionDataRequest {
             return when (jni) {
                 is JniTransactionDataRequest.GetStatus -> GetStatus(jni.txid)
                 is JniTransactionDataRequest.Enhancement -> Enhancement(jni.txid)
                 is JniTransactionDataRequest.SpendsFromAddress ->
                     SpendsFromAddress(
                         jni.address,
-                        BlockHeight.new(zcashNetwork, jni.startHeight),
+                        BlockHeight.new(jni.startHeight),
                         if (jni.endHeight == -1L) {
                             null
                         } else {
-                            BlockHeight.new(zcashNetwork, jni.endHeight)
+                            BlockHeight.new(jni.endHeight)
                         }
                     )
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/BlockHeightUnsafeExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/BlockHeightUnsafeExt.kt
@@ -1,9 +1,8 @@
 package cash.z.ecc.android.sdk.internal.model.ext
 
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 
 internal fun BlockHeightUnsafe.Companion.from(blockHeight: BlockHeight) = BlockHeightUnsafe(blockHeight.value)
 
-internal fun BlockHeightUnsafe.toBlockHeight(zcashNetwork: ZcashNetwork) = BlockHeight.new(zcashNetwork, value)
+internal fun BlockHeightUnsafe.toBlockHeight() = BlockHeight.new(value)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/CheckpointExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/CheckpointExt.kt
@@ -38,7 +38,7 @@ private fun Checkpoint.Companion.from(
             val height =
                 run {
                     val heightLong = jsonObject.getLong(Checkpoint.KEY_HEIGHT)
-                    BlockHeight.new(zcashNetwork, heightLong)
+                    BlockHeight.new(heightLong)
                 }
             val hash = jsonObject.getString(Checkpoint.KEY_HASH)
             val epochSeconds = jsonObject.getLong(Checkpoint.KEY_EPOCH_SECONDS)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/RawTransactionUnsafeExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/RawTransactionUnsafeExt.kt
@@ -1,15 +1,14 @@
 package cash.z.ecc.android.sdk.internal.model.ext
 
 import cash.z.ecc.android.sdk.internal.model.TransactionStatus
-import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.lightwallet.client.model.RawTransactionUnsafe
 import co.electriccoin.lightwallet.client.model.RawTransactionUnsafe.MainChain
 import co.electriccoin.lightwallet.client.model.RawTransactionUnsafe.Mempool
 import co.electriccoin.lightwallet.client.model.RawTransactionUnsafe.OrphanedBlock
 
-internal fun RawTransactionUnsafe.toTransactionStatus(network: ZcashNetwork): TransactionStatus {
+internal fun RawTransactionUnsafe.toTransactionStatus(): TransactionStatus {
     return when (this) {
-        is MainChain -> TransactionStatus.Mined(height.toBlockHeight(network))
+        is MainChain -> TransactionStatus.Mined(height.toBlockHeight())
         is Mempool -> TransactionStatus.NotInMainChain
         is OrphanedBlock -> TransactionStatus.NotInMainChain
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/BlockHeight.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/BlockHeight.kt
@@ -58,18 +58,9 @@ data class BlockHeight internal constructor(val value: Long) : Comparable<BlockH
         private val UINT_RANGE = 0.toLong()..UInt.MAX_VALUE.toLong()
 
         /**
-         * @param zcashNetwork Network to use for the block height.
-         * @param blockHeight The block height.  Must be in range of a UInt32 AND must be greater than the network's
-         * sapling activation height.
+         * @param blockHeight The block height.  Must be in range of a UInt32.
          */
-        fun new(
-            zcashNetwork: ZcashNetwork,
-            blockHeight: Long
-        ): BlockHeight {
-            require(blockHeight >= zcashNetwork.saplingActivationHeight.value) {
-                "Height $blockHeight is below sapling activation height ${zcashNetwork.saplingActivationHeight}"
-            }
-
+        fun new(blockHeight: Long): BlockHeight {
             return BlockHeight(blockHeight)
         }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/RawTransaction.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/RawTransaction.kt
@@ -21,15 +21,12 @@ data class RawTransaction internal constructor(
     }
 
     companion object {
-        fun new(
-            rawTransactionUnsafe: RawTransactionUnsafe,
-            network: ZcashNetwork
-        ): RawTransaction {
+        fun new(rawTransactionUnsafe: RawTransactionUnsafe): RawTransaction {
             return RawTransaction(
                 data = rawTransactionUnsafe.data,
                 height =
                     when (rawTransactionUnsafe) {
-                        is RawTransactionUnsafe.MainChain -> rawTransactionUnsafe.height.toBlockHeight(network)
+                        is RawTransactionUnsafe.MainChain -> rawTransactionUnsafe.height.toBlockHeight()
                         else -> null
                     }
             )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/CheckpointTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/CheckpointTool.kt
@@ -72,13 +72,12 @@ internal object CheckpointTool {
     internal fun checkpointDirectory(network: ZcashNetwork) =
         "co.electriccoin.zcash/checkpoint/${network.networkName.lowercase(Locale.ROOT)}"
 
-    internal fun checkpointHeightFromFilename(
-        zcashNetwork: ZcashNetwork,
-        fileName: String
-    ) = BlockHeight.new(zcashNetwork, fileName.split('.').first().toLong())
+    internal fun checkpointHeightFromFilename(fileName: String) = BlockHeight.new(fileName.split('.').first().toLong())
 
-    private fun Array<String>.sortDescending(zcashNetwork: ZcashNetwork) =
-        apply { sortByDescending { checkpointHeightFromFilename(zcashNetwork, it).value } }
+    private fun Array<String>.sortDescending() =
+        apply {
+            sortByDescending { checkpointHeightFromFilename(it).value }
+        }
 
     /**
      * Load the given birthday file from the assets of the given context. When no height is
@@ -97,7 +96,7 @@ internal object CheckpointTool {
     ): Checkpoint {
         Twig.debug { "loading checkpoint from assets: $birthday" }
         val directory = checkpointDirectory(network)
-        val treeFiles = getFilteredFileNames(context, network, directory, birthday)
+        val treeFiles = getFilteredFileNames(context, directory, birthday)
 
         Twig.debug { "found ${treeFiles.size} sapling tree checkpoints: $treeFiles" }
 
@@ -106,7 +105,6 @@ internal object CheckpointTool {
 
     private suspend fun getFilteredFileNames(
         context: Context,
-        network: ZcashNetwork,
         directory: String,
         birthday: BlockHeight?
     ): List<String> {
@@ -117,9 +115,9 @@ internal object CheckpointTool {
 
         val filteredTreeFiles =
             unfilteredTreeFiles
-                .sortDescending(network)
+                .sortDescending()
                 .filter { filename ->
-                    birthday?.let { checkpointHeightFromFilename(network, filename) <= it } ?: true
+                    birthday?.let { checkpointHeightFromFilename(filename) <= it } ?: true
                 }
 
         if (filteredTreeFiles.isEmpty()) {

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/model/BlockHeightTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/model/BlockHeightTest.kt
@@ -6,34 +6,24 @@ import kotlin.test.assertFailsWith
 
 class BlockHeightTest {
     @Test
-    fun new_mainnet_fails_below_sapling_activation_height() {
-        assertFailsWith(IllegalArgumentException::class) {
-            BlockHeight.new(
-                ZcashNetwork.Mainnet,
-                ZcashNetwork.Mainnet.saplingActivationHeight.value - 1
-            )
-        }
-    }
-
-    @Test
     fun new_mainnet_succeeds_at_sapling_activation_height() {
-        BlockHeight.new(ZcashNetwork.Mainnet, ZcashNetwork.Mainnet.saplingActivationHeight.value)
+        BlockHeight.new(ZcashNetwork.Mainnet.saplingActivationHeight.value)
     }
 
     @Test
     fun new_mainnet_succeeds_above_sapling_activation_height() {
-        BlockHeight.new(ZcashNetwork.Mainnet, ZcashNetwork.Mainnet.saplingActivationHeight.value + 10_000)
+        BlockHeight.new(ZcashNetwork.Mainnet.saplingActivationHeight.value + 10_000)
     }
 
     @Test
     fun new_mainnet_succeeds_at_max_value() {
-        BlockHeight.new(ZcashNetwork.Mainnet, UInt.MAX_VALUE.toLong())
+        BlockHeight.new(UInt.MAX_VALUE.toLong())
     }
 
     @Test
     fun new_fails_above_max_value() {
         assertFailsWith(IllegalArgumentException::class) {
-            BlockHeight.new(ZcashNetwork.Mainnet, UInt.MAX_VALUE.toLong() + 1)
+            BlockHeight.new(UInt.MAX_VALUE.toLong() + 1)
         }
     }
 
@@ -65,11 +55,10 @@ class BlockHeightTest {
     fun subtraction_of_block_height_succeeds() {
         val one =
             BlockHeight.new(
-                ZcashNetwork.Mainnet,
                 ZcashNetwork.Mainnet.saplingActivationHeight.value +
                     ZcashNetwork.Mainnet.saplingActivationHeight.value
             )
-        val two = BlockHeight.new(ZcashNetwork.Mainnet, ZcashNetwork.Mainnet.saplingActivationHeight.value)
+        val two = BlockHeight.new(ZcashNetwork.Mainnet.saplingActivationHeight.value)
 
         assertEquals(ZcashNetwork.Mainnet.saplingActivationHeight.value, one - two)
     }


### PR DESCRIPTION
- The check for sapling activation height inside the `BlockHeight` component is no longer correct
- These changes remove the mentioned check, and thus simplify many BlockHeight component usage, as the `ZcashNetwork` input parameter can now be removed.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [x] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._