### PR TITLE
Make `BlockHeightUnsafe` wrap `ULong` instead of `Long`

### DIFF
--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/BlockHeightUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/BlockHeightUnsafe.kt
@@ -5,14 +5,14 @@ package co.electriccoin.lightwallet.client.model
  *
  * It is marked as "unsafe" because it is not guaranteed to be valid.
  */
-data class BlockHeightUnsafe(val value: Long) : Comparable<BlockHeightUnsafe> {
+data class BlockHeightUnsafe(val value: ULong) : Comparable<BlockHeightUnsafe> {
     init {
-        require(UINT_RANGE.contains(value)) { "Height $value is outside of allowed range $UINT_RANGE" }
+        require(ULONG_RANGE.contains(value)) { "Height $value is outside of allowed range $ULONG_RANGE" }
     }
 
     override fun compareTo(other: BlockHeightUnsafe): Int = value.compareTo(other.value)
 
     companion object {
-        private val UINT_RANGE = 0.toLong()..UInt.MAX_VALUE.toLong()
+        private val ULONG_RANGE: ULongRange = 0.toULong()..UInt.MAX_VALUE.toULong()
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/BlockHeightUnsafeExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/BlockHeightUnsafeExt.kt
@@ -3,6 +3,6 @@ package cash.z.ecc.android.sdk.internal.model.ext
 import cash.z.ecc.android.sdk.model.BlockHeight
 import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 
-internal fun BlockHeightUnsafe.Companion.from(blockHeight: BlockHeight) = BlockHeightUnsafe(blockHeight.value)
+internal fun BlockHeightUnsafe.Companion.from(blockHeight: BlockHeight) = BlockHeightUnsafe(blockHeight.value.toULong())
 
-internal fun BlockHeightUnsafe.toBlockHeight() = BlockHeight.new(value)
+internal fun BlockHeightUnsafe.toBlockHeight() = BlockHeight.new(value.toLong())


### PR DESCRIPTION
Block heights are represented as `uint64` in all lightwalletd response types, so they should be parsed as ULong instead of Long values.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._