### PR TITLE
Remove the last `jboolean` error return from `backend-lib`

### DIFF
--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorLwdConn.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorLwdConn.kt
@@ -68,6 +68,6 @@ class TorLwdConn private constructor(
         private external fun submitTransaction(
             nativeHandle: Long,
             tx: ByteArray
-        ): Boolean
+        )
     }
 }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2746,7 +2746,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorLwdConn_submitTr
     _: JClass<'local>,
     lwd_conn: jlong,
     tx_bytes: JByteArray<'local>,
-) -> jboolean {
+) {
     let res = catch_unwind(&mut env, |env| {
         let lwd_conn = ptr::with_exposed_provenance_mut::<crate::tor::LwdConn>(lwd_conn as usize);
         let lwd_conn = unsafe { lwd_conn.as_mut() }
@@ -2754,11 +2754,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorLwdConn_submitTr
 
         let tx_bytes = utils::java_bytes_to_rust(env, &tx_bytes)?;
 
-        lwd_conn.send_transaction(tx_bytes)?;
-
-        Ok(JNI_TRUE)
+        lwd_conn.send_transaction(tx_bytes)
     });
-    unwrap_exc_or(&mut env, res, JNI_FALSE)
+    unwrap_exc_or(&mut env, res, ())
 }
 
 //


### PR DESCRIPTION
All other returns of a `jboolean` to indicate an error were removed in c78afc7d989bb74e1e375e38a62e472988495fe3.

fixes #1696

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._