### PR TITLE
Use Rust 1.84.1 in `action.yml`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,9 +22,8 @@ runs:
     - name: Setup Rust
       shell: bash
       run: |
-        # Rust 1.68+ is not compatible yet https://github.com/zcash/zcash-android-wallet-sdk/issues/958
-        rustup install 1.67.1
-        rustup default 1.67.1
+        rustup install 1.84.1
+        rustup default 1.84.1
         rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
     - name: Configure Gradle
       shell: bash


### PR DESCRIPTION
Error from CI:

```
info: installing component 'rustc'

  1.67.1-x86_64-unknown-linux-gnu installed - rustc 1.67.1 (d5a82bbd2 2023-02-07)

info: checking for self-update
info: downloading self-update
warn: tool `rust-analyzer` is already installed, remove it from `/home/runner/.cargo/bin`, then run `rustup update` to have rustup manage this tool.
warn: tool `rustfmt` is already installed, remove it from `/home/runner/.cargo/bin`, then run `rustup update` to have rustup manage this tool.
warn: tool `cargo-fmt` is already installed, remove it from `/home/runner/.cargo/bin`, then run `rustup update` to have rustup manage this tool.
info: using existing install for '1.67.1-x86_64-unknown-linux-gnu'
info: default toolchain set to '1.67.1-x86_64-unknown-linux-gnu'

  1.67.1-x86_64-unknown-linux-gnu unchanged - rustc 1.67.1 (d5a82bbd2 2023-02-07)
info: note that the toolchain '1.84.1-x86_64-unknown-linux-gnu' is currently in use (overridden by '/home/runner/work/zcash-android-wallet-sdk/zcash-android-wallet-sdk/rust-toolchain.toml')

error: toolchain '1.84.1-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install 1.84.1-x86_64-unknown-linux-gnu` to install it
Error: Process completed with exit code 1.
```

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._