### PR TITLE
Fetch UTXOs from height 0 internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Other dependencies update
 - Migrated to `zcash_client_backend 0.18.0`, `zcash_client_sqlite 0.16.0`
 - Added support for gap-limit-based discovery of transparent wallet addresses.
+- The internal fetch-utxos logic now fetches UTXOs from height 0 to support the Ledger funds rescue requirement
 
 ## [2.2.8] - 2025-03-03
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -680,7 +680,13 @@ class SdkSynchronizer private constructor(
     }
 
     private suspend fun refreshAllAccountsUtxos() {
-        getAccounts().forEach { refreshUtxos(it) }
+        getAccounts().forEach {
+            refreshUtxos(
+                account = it,
+                // Refreshing UTXOs from 0 to be able to discover e.g. blocked Ledger funds
+                since = BlockHeight(0)
+            )
+        }
     }
 
     private suspend fun dataMaintenance() {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -504,16 +504,13 @@ class CompactBlockProcessor internal constructor(
                         checkTransactions(transactionStorage = repository)
                     }
                     SyncingResult.FetchUtxos -> {
-                        Twig.info { "Triggering UTXOs fetching from: ${fullyScannedHeight.value}" }
-                        if (fullyScannedHeight.value == null) {
-                            Twig.info { "Postponing UTXOs fetching because fullyScannedHeight is null" }
-                        } else {
-                            backend.getAccounts().forEach {
-                                refreshUtxos(
-                                    account = it,
-                                    startHeight = fullyScannedHeight.value!!
-                                )
-                            }
+                        Twig.info { "Triggering UTXOs fetching" }
+                        backend.getAccounts().forEach {
+                            refreshUtxos(
+                                account = it,
+                                // Refreshing UTXOs from 0 to be able to discover e.g. blocked Ledger funds
+                                startHeight = BlockHeight(0)
+                            )
                         }
                     }
                     is SyncingResult.Failure -> {
@@ -617,16 +614,13 @@ class CompactBlockProcessor internal constructor(
                         SyncingResult.AllSuccess
                     }
                     SyncingResult.FetchUtxos -> {
-                        Twig.info { "Triggering UTXOs fetching from: ${fullyScannedHeight.value}" }
-                        if (fullyScannedHeight.value == null) {
-                            Twig.info { "Postponing UTXOs fetching because fullyScannedHeight is null" }
-                        } else {
-                            backend.getAccounts().forEach {
-                                refreshUtxos(
-                                    account = it,
-                                    startHeight = fullyScannedHeight.value!!
-                                )
-                            }
+                        Twig.info { "Triggering UTXOs fetching" }
+                        backend.getAccounts().forEach {
+                            refreshUtxos(
+                                account = it,
+                                // Refreshing UTXOs from 0 to be able to discover e.g. blocked Ledger funds
+                                startHeight = BlockHeight(0)
+                            )
                         }
                         SyncingResult.AllSuccess
                     }


### PR DESCRIPTION
This changes the way how SDK internally calls `fetchUtxos`. It polls from height 0 instead of `fullyScannedHeight` to support Ledger funds rescue. cc @nuttycom  

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [x] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._